### PR TITLE
Remove deprecated GoogleTest call

### DIFF
--- a/src/enrichment_tests.cc
+++ b/src/enrichment_tests.cc
@@ -584,7 +584,7 @@ int ConnectAgentTests();
 static int cyclus_agent_tests_connected = ConnectAgentTests();
 #define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
 #endif  // CYCLUS_AGENT_TESTS_CONNECTED
-INSTANTIATE_TEST_CASE_P(FlexibleEnrichment, FacilityTests,
-                        ::testing::Values(&FlexibleEnrichmentConstructor));
-INSTANTIATE_TEST_CASE_P(FlexibleEnrichment, AgentTests,
-                        ::testing::Values(&FlexibleEnrichmentConstructor));
+INSTANTIATE_TEST_SUITE_P(FlexibleEnrichment, FacilityTests,
+                         ::testing::Values(&FlexibleEnrichmentConstructor));
+INSTANTIATE_TEST_SUITE_P(FlexibleEnrichment, AgentTests,
+                         ::testing::Values(&FlexibleEnrichmentConstructor));

--- a/src/pakistan_enrichment_tests.cc
+++ b/src/pakistan_enrichment_tests.cc
@@ -26,7 +26,7 @@ int ConnectAgentTests();
 static int cyclus_agent_tests_connected = ConnectAgentTests();
 #define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
 #endif  // CYCLUS_AGENT_TESTS_CONNECTED
-INSTANTIATE_TEST_CASE_P(PakistanEnrichment, FacilityTests,
-                        ::testing::Values(&PakistanEnrichmentConstructor));
-INSTANTIATE_TEST_CASE_P(PakistanEnrichment, AgentTests,
-                        ::testing::Values(&PakistanEnrichmentConstructor));
+INSTANTIATE_TEST_SUITE_P(PakistanEnrichment, FacilityTests,
+                         ::testing::Values(&PakistanEnrichmentConstructor));
+INSTANTIATE_TEST_SUITE_P(PakistanEnrichment, AgentTests,
+                         ::testing::Values(&PakistanEnrichmentConstructor));

--- a/src/sink_tests.cc
+++ b/src/sink_tests.cc
@@ -330,7 +330,7 @@ int ConnectAgentTests();
 static int cyclus_agent_tests_connected = ConnectAgentTests();
 #define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
 #endif  // CYCLUS_AGENT_TESTS_CONNECTED
-INSTANTIATE_TEST_CASE_P(FlexibleSinkFac, FacilityTests,
-                        ::testing::Values(&FlexibleSinkConstructor));
-INSTANTIATE_TEST_CASE_P(FlexibleSinkFac, AgentTests,
-                        ::testing::Values(&FlexibleSinkConstructor));
+INSTANTIATE_TEST_SUITE_P(FlexibleSinkFac, FacilityTests,
+                         ::testing::Values(&FlexibleSinkConstructor));
+INSTANTIATE_TEST_SUITE_P(FlexibleSinkFac, AgentTests,
+                         ::testing::Values(&FlexibleSinkConstructor));

--- a/src/source_tests.cc
+++ b/src/source_tests.cc
@@ -208,8 +208,8 @@ static int cyclus_agent_tests_connected = ConnectAgentTests();
 #define CYCLUS_AGENT_TESTS_CONNECTED cyclus_agent_tests_connected
 #endif  // CYCLUS_AGENT_TESTS_CONNECTED
 
-INSTANTIATE_TEST_CASE_P(FlexibleSource, FacilityTests,
-                        ::testing::Values(&FlexibleSourceConstructor));
-INSTANTIATE_TEST_CASE_P(FlexibleSource, AgentTests,
-                        ::testing::Values(&FlexibleSourceConstructor));
+INSTANTIATE_TEST_SUITE_P(FlexibleSource, FacilityTests,
+                         ::testing::Values(&FlexibleSourceConstructor));
+INSTANTIATE_TEST_SUITE_P(FlexibleSource, AgentTests,
+                         ::testing::Values(&FlexibleSourceConstructor));
 


### PR DESCRIPTION
The compiler warning was the following:
warning: ‘constexpr bool testing::internal::InstantiateTestCase_P_IsDeprecated()’ is deprecated: INSTANTIATE_TEST_CASE_P is deprecated, please use INSTANTIATE_TEST_SUITE_P [-Wdeprecated-declarations]